### PR TITLE
Add check for the result of cd into

### DIFF
--- a/pushToBintray.sh
+++ b/pushToBintray.sh
@@ -24,6 +24,11 @@ echo "${PATH_TO_REPOSITORY}"
 
 if [ ! -z "$PATH_TO_REPOSITORY" ]; then
    cd $PATH_TO_REPOSITORY
+   if [ $? -ne 0 ]; then
+     #directory does not exist
+     echo $PATH_TO_REPOSITORY " does not exist"
+     exit 1
+   fi
 fi
 
 


### PR DESCRIPTION
This pull request adds a check in case the "cd $PATH_TO_REPOSITORY" didn't work. 
In that case, it exits with an error code (rather than continuing the script execution with an uncontrolled behaviour).
